### PR TITLE
Refresh Control starts animating as soon as the view is presented

### DIFF
--- a/Sources/PullToRefresh.swift
+++ b/Sources/PullToRefresh.swift
@@ -62,19 +62,24 @@ private struct PullToRefresh: UIViewRepresentable {
             guard let tableView = self.tableView(entry: uiView) else {
                 return
             }
+
+            if tableView.refreshControl == nil {
+                let refreshControl = UIRefreshControl()
+                refreshControl.addTarget(context.coordinator, action: #selector(Coordinator.onValueChanged), for: .valueChanged)
+                tableView.refreshControl = refreshControl
+            }
             
             if let refreshControl = tableView.refreshControl {
                 if self.isShowing {
+                    if !refreshControl.isRefreshing {
+                        tableView.setContentOffset(CGPoint(x: 0, y: tableView.contentOffset.y - refreshControl.frame.size.height), animated: true)
+                    }
+
                     refreshControl.beginRefreshing()
                 } else {
                     refreshControl.endRefreshing()
                 }
-                return
             }
-            
-            let refreshControl = UIRefreshControl()
-            refreshControl.addTarget(context.coordinator, action: #selector(Coordinator.onValueChanged), for: .valueChanged)
-            tableView.refreshControl = refreshControl
         }
     }
     


### PR DESCRIPTION
Implements #3 

Reordering of the UIRefreshControl creation and set up removes the need to reset the `@State` value in `viewDidAppear`. Why was the ordering such in the first place? Was it fixing any other issue?

![Screen Recording 2020-05-18 at 22 09 45 2020-05-18 22_14_47](https://user-images.githubusercontent.com/7377418/82255511-0f870c00-9955-11ea-99ca-4e673053b29a.gif)


