### PR TITLE
fixed animations / scrolling bad behaviours

### DIFF
--- a/Sources/PullToRefresh.swift
+++ b/Sources/PullToRefresh.swift
@@ -66,7 +66,8 @@ private struct PullToRefresh: UIViewRepresentable {
             if let refreshControl = tableView.refreshControl {
                 if self.isShowing {
                     refreshControl.beginRefreshing()
-                } else {
+                    
+                } else if refreshControl.isRefreshing {
                     refreshControl.endRefreshing()
                 }
                 return


### PR DESCRIPTION
animations while scrolling the List get stuck due to endRefreshing being called too many times.
It can be seen happening when using the scrollTo method of a ScrollViewReader or when scrolling and loading new pages to a List at the same time, for example 