### PR TITLE
Fix "infinite list" array update -> lost inertia

### DIFF
--- a/Sources/PullToRefresh.swift
+++ b/Sources/PullToRefresh.swift
@@ -65,9 +65,13 @@ private struct PullToRefresh: UIViewRepresentable {
             
             if let refreshControl = tableView.refreshControl {
                 if self.isShowing {
-                    refreshControl.beginRefreshing()
+                    if !refreshControl.isRefreshing {
+                        refreshControl.beginRefreshing()
+                    }
                 } else {
-                    refreshControl.endRefreshing()
+                    if refreshControl.isRefreshing {
+                        refreshControl.endRefreshing()
+                    }
                 }
                 return
             }


### PR DESCRIPTION
Fix "infinite list" or when List array is being updated,
the "refreshControl" will update itself regardless of its current status.

When the "refreshControl" attempts to update its refreshing status by "beginRefreshing" or "endRefreshing",
List / UITableView scrolling will lose its inertia / acceleration. The inertia scroll will be stopped. The behavior is strange.